### PR TITLE
EARTH-89: Cleaned up challenge areas view.

### DIFF
--- a/config/install/views.view.challenge_areas.yml
+++ b/config/install/views.view.challenge_areas.yml
@@ -84,44 +84,63 @@ display:
               weight: 2
               plugin: views_row
               source: path
+          variants:
+            arrow:
+              constant_value: has-arrow
+              dynamic_value: ''
       fields:
         title:
           id: title
           table: node_field_data
           field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
           relationship: none
           group_type: group
           admin_label: ''
+          label: ''
           exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
           element_type: ''
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -132,6 +151,9 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
         field_research_area_thumbnail:
           id: field_research_area_thumbnail
           table: node__field_research_area_thumbnail
@@ -184,7 +206,7 @@ display:
           type: image
           settings:
             image_style: component_film_card
-            image_link: content
+            image_link: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -237,7 +259,7 @@ display:
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: ''
+          element_wrapper_type: '0'
           element_wrapper_class: ''
           element_default_classes: false
           empty: ''
@@ -326,6 +348,7 @@ display:
       arguments: {  }
       display_extenders: {  }
       show_admin_links: false
+      css_class: filmstrip
     cache_metadata:
       max-age: -1
       contexts:

--- a/stanford_research_area.info.yml
+++ b/stanford_research_area.info.yml
@@ -21,6 +21,7 @@ dependencies:
   - scheduler
   - stanford_paragraph_hero_banner
   - stanford_paragraph_postcard
+  - stanford_paragraph_slide
   - taxonomy
   - text
   - ui_patterns_views


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Cleans up the challenge areas view that is attached to a view_field p-type on the home page. Right now it renders too many anchor tags.

# Needed By (Date)
- Wednesday 23rd

# Urgency
- Low

# Steps to Test

1. Pull this branch
2. Revert the feature
3. Clear the cache
4. Review the look and markup of the view on the home page.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)