### PR TITLE
EARTH-515: Allow for menu placement and scheduled publish/unpublish.

### DIFF
--- a/config/install/node.type.research_area.yml
+++ b/config/install/node.type.research_area.yml
@@ -6,19 +6,20 @@ dependencies:
     - scheduler
 third_party_settings:
   menu_ui:
-    available_menus: {  }
-    parent: ''
+    available_menus:
+      - main
+    parent: 'main:'
   scheduler:
     expand_fieldset: when_required
     fields_display_mode: vertical_tab
-    publish_enable: false
+    publish_enable: true
     publish_past_date: error
     publish_required: false
-    publish_revision: false
+    publish_revision: true
     publish_touch: false
-    unpublish_enable: false
+    unpublish_enable: true
     unpublish_required: false
-    unpublish_revision: false
+    unpublish_revision: true
 name: 'Research Area'
 type: research_area
 description: 'Landing pages for Research Areas and Challenge Areas, each keyed to a Research Area taxonomy term.'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds the ability for content authors to put research areas in the main menu
- Adds the ability for content authors to schedule and unschedule publishing

# Needed By (Date)
- Sometime before MVP launch

# Urgency
- Low

# Steps to Test

1. Check out this branch
2. Revert this feature (`drush features-import stanford_research_area -y`)
3. Clear caches (`drush cr`)
4. Edit a research page (`/securing-energy-future`) and ensure menu and scheduling options are available.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)